### PR TITLE
fixes test alignment issue and diff backslash issue

### DIFF
--- a/ref_diffs/bar/law_FALSE-RETURNS_18_00.diff
+++ b/ref_diffs/bar/law_FALSE-RETURNS_18_00.diff
@@ -1,6 +1,6 @@
 18c18
 <     return a + b
-\\ No newline at end of file
+\ No newline at end of file
 ---
 >     return False
-\\ No newline at end of file
+\ No newline at end of file

--- a/ref_diffs/bar/law_MATH_18_00.diff
+++ b/ref_diffs/bar/law_MATH_18_00.diff
@@ -1,6 +1,6 @@
 18c18
 <     return a + b
-\\ No newline at end of file
+\ No newline at end of file
 ---
 >     return a - b
-\\ No newline at end of file
+\ No newline at end of file

--- a/ref_diffs/bar/law_NULL-RETURNS_18_00.diff
+++ b/ref_diffs/bar/law_NULL-RETURNS_18_00.diff
@@ -1,6 +1,6 @@
 18c18
 <     return a + b
-\\ No newline at end of file
+\ No newline at end of file
 ---
 >     return None
-\\ No newline at end of file
+\ No newline at end of file

--- a/ref_diffs/bar/law_TRUE-RETURNS_18_00.diff
+++ b/ref_diffs/bar/law_TRUE-RETURNS_18_00.diff
@@ -1,6 +1,6 @@
 18c18
 <     return a + b
-\\ No newline at end of file
+\ No newline at end of file
 ---
 >     return True
-\\ No newline at end of file
+\ No newline at end of file

--- a/ref_diffs/bar/lazy_FALSE-RETURNS_52_00.diff
+++ b/ref_diffs/bar/lazy_FALSE-RETURNS_52_00.diff
@@ -1,6 +1,6 @@
 52c52
 <     return help_sort3(arr, 0, len(arr) - 1)
-\\ No newline at end of file
+\ No newline at end of file
 ---
 >     return False
-\\ No newline at end of file
+\ No newline at end of file

--- a/ref_diffs/bar/lazy_MATH_52_00.diff
+++ b/ref_diffs/bar/lazy_MATH_52_00.diff
@@ -1,6 +1,6 @@
 52c52
 <     return help_sort3(arr, 0, len(arr) - 1)
-\\ No newline at end of file
+\ No newline at end of file
 ---
 >     return help_sort3(arr, 0, len(arr) + 1)
-\\ No newline at end of file
+\ No newline at end of file

--- a/ref_diffs/bar/lazy_NULL-RETURNS_52_00.diff
+++ b/ref_diffs/bar/lazy_NULL-RETURNS_52_00.diff
@@ -1,6 +1,6 @@
 52c52
 <     return help_sort3(arr, 0, len(arr) - 1)
-\\ No newline at end of file
+\ No newline at end of file
 ---
 >     return None
-\\ No newline at end of file
+\ No newline at end of file

--- a/ref_diffs/bar/lazy_TRUE-RETURNS_52_00.diff
+++ b/ref_diffs/bar/lazy_TRUE-RETURNS_52_00.diff
@@ -1,6 +1,6 @@
 52c52
 <     return help_sort3(arr, 0, len(arr) - 1)
-\\ No newline at end of file
+\ No newline at end of file
 ---
 >     return True
-\\ No newline at end of file
+\ No newline at end of file

--- a/ref_diffs/bar/simple_FALSE-RETURNS_37_00.diff
+++ b/ref_diffs/bar/simple_FALSE-RETURNS_37_00.diff
@@ -1,6 +1,6 @@
 37c37
 <         return a & c
-\\ No newline at end of file
+\ No newline at end of file
 ---
 >         return False
-\\ No newline at end of file
+\ No newline at end of file

--- a/ref_diffs/bar/simple_MATH_37_00.diff
+++ b/ref_diffs/bar/simple_MATH_37_00.diff
@@ -1,6 +1,6 @@
 37c37
 <         return a & c
-\\ No newline at end of file
+\ No newline at end of file
 ---
 >         return a | c
-\\ No newline at end of file
+\ No newline at end of file

--- a/ref_diffs/bar/simple_NULL-RETURNS_37_00.diff
+++ b/ref_diffs/bar/simple_NULL-RETURNS_37_00.diff
@@ -1,6 +1,6 @@
 37c37
 <         return a & c
-\\ No newline at end of file
+\ No newline at end of file
 ---
 >         return None
-\\ No newline at end of file
+\ No newline at end of file

--- a/ref_diffs/bar/simple_OBBN1_37_00.diff
+++ b/ref_diffs/bar/simple_OBBN1_37_00.diff
@@ -1,6 +1,6 @@
 37c37
 <         return a & c
-\\ No newline at end of file
+\ No newline at end of file
 ---
 >         return a | c
-\\ No newline at end of file
+\ No newline at end of file

--- a/ref_diffs/bar/simple_OBBN2_37_00.diff
+++ b/ref_diffs/bar/simple_OBBN2_37_00.diff
@@ -1,6 +1,6 @@
 37c37
 <         return a & c
-\\ No newline at end of file
+\ No newline at end of file
 ---
 >         return a
-\\ No newline at end of file
+\ No newline at end of file

--- a/ref_diffs/bar/simple_OBBN3_37_00.diff
+++ b/ref_diffs/bar/simple_OBBN3_37_00.diff
@@ -1,6 +1,6 @@
 37c37
 <         return a & c
-\\ No newline at end of file
+\ No newline at end of file
 ---
 >         return c
-\\ No newline at end of file
+\ No newline at end of file

--- a/ref_diffs/bar/simple_TRUE-RETURNS_37_00.diff
+++ b/ref_diffs/bar/simple_TRUE-RETURNS_37_00.diff
@@ -1,6 +1,6 @@
 37c37
 <         return a & c
-\\ No newline at end of file
+\ No newline at end of file
 ---
 >         return True
-\\ No newline at end of file
+\ No newline at end of file

--- a/ref_diffs/foo/math_FALSE-RETURNS_19_00.diff
+++ b/ref_diffs/foo/math_FALSE-RETURNS_19_00.diff
@@ -1,6 +1,6 @@
 19c19
 <         return foo1(a, c, 0, 3)
-\\ No newline at end of file
+\ No newline at end of file
 ---
 >         return False
-\\ No newline at end of file
+\ No newline at end of file

--- a/ref_diffs/foo/math_NULL-RETURNS_19_00.diff
+++ b/ref_diffs/foo/math_NULL-RETURNS_19_00.diff
@@ -1,6 +1,6 @@
 19c19
 <         return foo1(a, c, 0, 3)
-\\ No newline at end of file
+\ No newline at end of file
 ---
 >         return None
-\\ No newline at end of file
+\ No newline at end of file

--- a/ref_diffs/foo/math_TRUE-RETURNS_19_00.diff
+++ b/ref_diffs/foo/math_TRUE-RETURNS_19_00.diff
@@ -1,6 +1,6 @@
 19c19
 <         return foo1(a, c, 0, 3)
-\\ No newline at end of file
+\ No newline at end of file
 ---
 >         return True
-\\ No newline at end of file
+\ No newline at end of file

--- a/ref_diffs/foo/simple_FALSE-RETURNS_23_00.diff
+++ b/ref_diffs/foo/simple_FALSE-RETURNS_23_00.diff
@@ -1,6 +1,6 @@
 23c23
 <     return str(34) + ' + ' + str(x)
-\\ No newline at end of file
+\ No newline at end of file
 ---
 >     return False
-\\ No newline at end of file
+\ No newline at end of file

--- a/ref_diffs/foo/simple_MATH_23_00.diff
+++ b/ref_diffs/foo/simple_MATH_23_00.diff
@@ -1,6 +1,6 @@
 23c23
 <     return str(34) + ' + ' + str(x)
-\\ No newline at end of file
+\ No newline at end of file
 ---
 >     return str(34) + ' + ' - str(x)
-\\ No newline at end of file
+\ No newline at end of file

--- a/ref_diffs/foo/simple_MATH_23_01.diff
+++ b/ref_diffs/foo/simple_MATH_23_01.diff
@@ -1,6 +1,6 @@
 23c23
 <     return str(34) + ' + ' + str(x)
-\\ No newline at end of file
+\ No newline at end of file
 ---
 >     return str(34) - ' + ' + str(x)
-\\ No newline at end of file
+\ No newline at end of file

--- a/ref_diffs/foo/simple_NULL-RETURNS_23_00.diff
+++ b/ref_diffs/foo/simple_NULL-RETURNS_23_00.diff
@@ -1,6 +1,6 @@
 23c23
 <     return str(34) + ' + ' + str(x)
-\\ No newline at end of file
+\ No newline at end of file
 ---
 >     return None
-\\ No newline at end of file
+\ No newline at end of file

--- a/ref_diffs/foo/simple_TRUE-RETURNS_23_00.diff
+++ b/ref_diffs/foo/simple_TRUE-RETURNS_23_00.diff
@@ -1,6 +1,6 @@
 23c23
 <     return str(34) + ' + ' + str(x)
-\\ No newline at end of file
+\ No newline at end of file
 ---
 >     return True
-\\ No newline at end of file
+\ No newline at end of file

--- a/test_c_kill_matrix.py
+++ b/test_c_kill_matrix.py
@@ -27,7 +27,7 @@ def test_foo_km():
     stu_matrix = np.loadtxt(os.path.join(stu_path, MATRIX_FILE), dtype=np.int32)
     stu_shift_matrix = stu_matrix[row_permutation, :]
     stu_shift_matrix = stu_shift_matrix[:, col_permutation]
-    assert np.all(ref_matrix == stu_matrix)
+    assert np.all(ref_matrix == stu_shift_matrix)
 
 def test_bar_km():
     stu_path = STU_BAR_KM_PATH
@@ -42,7 +42,5 @@ def test_bar_km():
     stu_matrix = np.loadtxt(os.path.join(stu_path, MATRIX_FILE), dtype=np.int32)
     stu_shift_matrix = stu_matrix[row_permutation, :]
     stu_shift_matrix = stu_shift_matrix[:, col_permutation]
-    assert np.all(ref_matrix == stu_matrix)
+    assert np.all(ref_matrix == stu_shift_matrix)
 
-if __name__ == '__main__':
-    test_foo_km()


### PR DESCRIPTION
 * The kill matrix test code was written so that the reference and student matrices would be aligned regardless of mutant/test order, but was not actually using the aligned copy to compare with the student's answer. This is fixed.
 * The captured output of the `diff` command had two backslashes when printed results from `diff`'s `stdout` only show 1 backslash. This is a python printing issue. The problematic diff files are fixed.